### PR TITLE
feat: allow testRails run select test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ it("Can authenticate a valid userC123", ...
 
 **runName**: _string_ (optional) name of the Testrail run.
 
-**includeAllInTestRun**: _bool_ (default is true) will return all test cases in test run. set to false to return test runs based on filter or section/group.
+**includeAllInTestRun**: _bool_ (optional: default is true) will return all test cases in test run. set to false to return test runs based on filter or section/group.
 
 **groupId**: _string_ (optional: needs "includeAllInTestRun": false ) The ID of the section/group
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ it("Can authenticate a valid userC123", ...
 
 **runName**: _string_ (optional) name of the Testrail run.
 
+**includeAllInTestRun**: _bool_ (default is true) will return all test cases in test run. set to false to return test runs based on filter or section/group.
+
+**groupId**: _string_ (optional: needs "includeAllInTestRun": false ) The ID of the section/group
+
+**groupId**: _string_ (optional: needs "includeAllInTestRun": false) Only return cases with matching filter string in the case title
+
 ## TestRail Settings
 
 To increase security, the TestRail team suggests using an API key instead of a password. You can see how to generate an API key [here](http://docs.gurock.com/testrail-api2/accessing#username_and_api_key).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ it("Can authenticate a valid userC123", ...
 
 **groupId**: _string_ (optional: needs "includeAllInTestRun": false ) The ID of the section/group
 
-**groupId**: _string_ (optional: needs "includeAllInTestRun": false) Only return cases with matching filter string in the case title
+**filter**: _string_ (optional: needs "includeAllInTestRun": false) Only return cases with matching filter string in the case title
 
 ## TestRail Settings
 

--- a/dist/testrail.js
+++ b/dist/testrail.js
@@ -6,31 +6,9 @@ var TestRail = /** @class */ (function () {
     function TestRail(options) {
         this.options = options;
         this.base = "https://" + options.domain + "/index.php?/api/v2";
-    };
-    TestRail.prototype.getCases = async function(){
-        var casesArray = await axios({
-            method:'get',
-            url:this.base + "/get_cases/"+this.options.projectId+"&suite_id="+this.options.suiteId+"&section_id="+this.options.groupId+"&filter="+this.options.filter, 
-            headers: { 'Content-Type': 'application/json' }, 
-            auth: {
-                username: this.options.username,
-                password: this.options.password
-            } 
-          }  
-        ).then(function (response) {   
-            return response.data.map(item =>item.id);
-        })
-            .catch(function (error) { return console.error(error); });
-            return casesArray;
-    };
-    TestRail.prototype.createRun = async function (name, description) {
+    }
+    TestRail.prototype.createRun = function (name, description) {
         var _this = this;
-        _this.includeALL = true;
-        _this.caseNumbersArray = [];
-         if(this.options.includeAllInTestRun == false){
-            _this.caseNumbersArray =  await _this.getCases();
-            _this.includeALL = false;
-         }   
         axios({
             method: 'post',
             url: this.base + "/add_run/" + this.options.projectId,
@@ -43,8 +21,7 @@ var TestRail = /** @class */ (function () {
                 suite_id: this.options.suiteId,
                 name: name,
                 description: description,
-                include_all: _this.includeALL,
-                case_ids: _this.caseNumbersArray
+                include_all: true,
             }),
         })
             .then(function (response) {

--- a/src/lib/testrail.interface.ts
+++ b/src/lib/testrail.interface.ts
@@ -5,6 +5,9 @@ export interface TestRailOptions {
   projectId: number;
   suiteId: number;
   assignedToId?: number;
+  includeAllInTestRun?: boolean;
+  groupId?: number;
+  filter?: string;
 }
 
 export enum Status {


### PR DESCRIPTION
Allowing backwards compatibility , I have added three Reporter options:
 
**includeAllInTestRun**: _bool_ (optional:  default is true) will return all test cases in test run. set to false to return test runs based on filter or section/group.

**groupId**: _string_ (optional: needs "includeAllInTestRun": false ) The ID of the section/group

**filter**: _string_ (optional: needs "includeAllInTestRun": false) Only return cases with matching filter string in the case title