### PR TITLE
Fixing purge of testrail-cache.txt

### DIFF
--- a/src/lib/cypress-testrail-reporter.ts
+++ b/src/lib/cypress-testrail-reporter.ts
@@ -111,6 +111,9 @@ export class CypressTestRailReporter extends reporters.Spec {
          */
         var numSpecFiles = this.testRailValidation.countTestSpecFiles();
         var counter = TestRailCache.retrieve('runCounter');
+        // load runId before purging testrail-cache.txt
+        this.runId = TestRailCache.retrieve('runId');
+
         if (numSpecFiles.length > counter) {
           runCounter++
         } else {
@@ -127,7 +130,6 @@ export class CypressTestRailReporter extends reporters.Spec {
         if (this.results.length == 0) {
           TestRailLogger.warn('No testcases were matched with TestRail. Ensure that your tests are declared correctly and titles contain matches to format of Cxxxx');
         } else {
-          this.runId = TestRailCache.retrieve('runId');
           var path = `runs/view/${this.runId}`;
           TestRailLogger.log(`Results are published to ${chalk.magenta(`${this.reporterOptions.host}/index.php?/${path}`)}`);
         }


### PR DESCRIPTION
Reports are breaking sometimes because of the lack of testrail-cache.txt file, at the end of all tests. This PR fixes this behavior.